### PR TITLE
Add feature specs for adding questions & choices

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -3,6 +3,9 @@ class PoolsController < ApplicationController
 
   def show
     @pool = current_user.pools.find(params[:id])
+    @questions = @pool.questions
+    @question = @pool.questions.new
+    2.times { @question.choices.build }
   end
 
   def new

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,20 @@
+class QuestionsController < ApplicationController
+  def create
+    pool = current_user.pools.find(question_params[:pool_id])
+    @question = pool.questions.new(question_params)
+    authorize @question
+    return redirect_to pool if not_enough_choices?
+    @question.save
+    redirect_to pool
+  end
+
+  private 
+
+  def question_params
+    params.require(:question).permit(:text, :pool_id, choices_attributes: [:text, :points])
+  end
+
+  def not_enough_choices?
+    @question.choices.map(&:new_record?).count == 1
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,12 @@
 class Question < ApplicationRecord
   belongs_to :pool
   has_many :choices
+
+  accepts_nested_attributes_for :choices, reject_if: :reject_blank_choices
+
+  validates :text, presence: true, uniqueness: { scope: :pool_id }
+
+  def reject_blank_choices(attributes)
+    attributes["text"].blank?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
 
   has_many :pools
   has_many :memberships
+
+  def is_admin?(pool)
+    memberships.where(pool: pool, role: 1) || pool.user == self
+  end
 end

--- a/app/policies/question_policy.rb
+++ b/app/policies/question_policy.rb
@@ -1,0 +1,11 @@
+class QuestionPolicy < ApplicationPolicy
+  def create?
+    user.is_admin?(record.pool)
+  end
+  
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -1,10 +1,33 @@
 <%= @pool.name %>
 
-Create entries
-
 <% if policy(@pool).admin? %>
   <% @pool.memberships.each do |membership| %>
     <%= membership.user.email %>
     <%= button_to "Remove User", membership, method: :delete %>
+  <% end %>
+
+  <h2>Create questions</h2>
+  <%= form_for @question do |f| %>
+    <%= f.hidden_field :pool_id, value: @pool.id %>
+    <%= f.label :text, "Question text" %>
+    <%= f.text_field :text %>
+    <%= f.fields_for :choices do |ff| %>
+      <%= ff.label :text, "Choice text" %>
+      <%= ff.text_field :text %>
+    <% end %>
+
+    <%= f.submit "Create Question!" %>
+  <% end %>
+  <h3>Existing questions</h3>
+  <% @questions.each do |question| %>
+    <ul>
+      <li><%= question.text %></li>
+      <ul>
+        <% question.choices.each do |choice| %>
+          <li><%= choice.text %></li>
+        <% end %>
+      </ul>
+    </ul>
+    
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   end
 
   resources :memberships, only: [:index, :create, :destroy]
+  resources :questions, only: [:index, :create]
 end

--- a/spec/features/pools/user_can_create_pool_spec.rb
+++ b/spec/features/pools/user_can_create_pool_spec.rb
@@ -19,7 +19,7 @@ describe 'User can create pool', type: :feature do
       click_button("Create Pool!")
 
       expect(page).to have_content(pool_name)
-      expect(page).to have_content("Create entries")
+      expect(page).to have_content("Create questions")
     end
   end
 end

--- a/spec/features/questions/admin_can_create_questions_in_a_pool_spec.rb
+++ b/spec/features/questions/admin_can_create_questions_in_a_pool_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe "Admin can create questions in a pool", type: :feature do
+  let(:pool) { create(:pool) }
+  let(:user) { pool.user }
+  let(:question_text) { "Who will win Superb Owl 55?" }
+  
+  before { login_as(user, scope: :user) }
+  
+  describe "can create a question without any choices" do
+    it "creates a question and redirects back to pool path" do
+      visit pool_path(pool)
+
+      fill_in "Question text", with: question_text
+      click_button "Create Question!"
+
+      expect(page).to have_content(question_text)
+    end
+  end
+
+  describe "with choices" do
+    let(:choice_one) { "Kansas City Chiefs" }
+
+    describe "can create a question with at least 2 choices" do
+      let(:choice_two) { "Tampa Bay Buccaneers" }
+
+      it "creates a question with 2 choices and redirects back to pool path" do
+        visit pool_path(pool)
+
+        fill_in "Question text", with: question_text
+        fill_in "question_choices_attributes_0_text", with: choice_one
+        fill_in "question_choices_attributes_1_text", with: choice_two
+        click_button "Create Question!"
+        
+        expect(page).to have_content(question_text)
+        expect(page).to have_content(choice_one)
+        expect(page).to have_content(choice_two)
+      end
+    end
+    
+    describe "cannot create a question with 1 choice" do
+      it "does not create a question or chocies and redirects back to pool path" do
+        visit pool_path(pool)
+        
+        fill_in "Question text", with: question_text
+        fill_in "question_choices_attributes_0_text", with: choice_one
+        click_button "Create Question!"
+
+        expect(page).to have_content(pool.name)
+        expect(page).not_to have_content(question_text)
+        expect(page).not_to have_content(choice_one)
+      end
+    end
+  end
+
+  describe "can create a question with more than 2 choices"
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -4,9 +4,15 @@ describe Question, type: :model do
   describe "relationships" do
     it { should belong_to :pool }
     it { should have_many :choices }
+    it { should accept_nested_attributes_for :choices }
   end
+  
+  describe "validations" do
+    before { create(:question) }
 
-  describe "validations"
+    it { should validate_presence_of :text }
+    it { should validate_uniqueness_of(:text).scoped_to(:pool_id) }
+  end
 
   describe "methods"
 end

--- a/spec/policies/question_policy_spec.rb
+++ b/spec/policies/question_policy_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe QuestionPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+end

--- a/spec/requests/questions_controller_request_spec.rb
+++ b/spec/requests/questions_controller_request_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe QuestionsController, type: :request do
+  let(:pool) { create(:pool) }
+  let(:user) { pool.user }
+
+  before { sign_in(user) }
+
+  describe "POST#create" do
+    subject(:post_create) { post questions_path, params: attrs }
+    
+    describe "success" do
+      let(:attrs) { { question: { text: "Question text", pool_id: pool.id } } }
+
+      it "has 302 status" do
+        post_create
+        
+        expect(response).to have_http_status(302)
+      end
+
+      it "creates a new question" do
+        expect { post_create }.to change(Question, :count).by(1)
+      end
+    end
+
+    describe "failure" do
+      let(:attrs) { { question: { text: "", pool_id: pool.id } } }
+
+      it "has 302 status" do
+        post_create
+        
+        expect(response).to have_http_status(302)
+      end
+
+      it "does not create a new question" do
+        expect { post_create }.not_to change(Question, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

- Closes #19 

# Description

An admin on a pool should be able to add a question with choices from the pool#show page.

#Approach

This PR will allow an admin to add a question without any choices or 2 or more choices. It will block question creation if a question is created with just one choice.