### PR TITLE
Add started_at to pools table

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -1,8 +1,8 @@
 class PoolsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_pool, except: [:new, :create, :membership]
 
   def show
-    @pool = current_user.participating_pools.find(params[:id])
     @questions = @pool.saved_questions
     @question = @pool.questions.new
     2.times { @question.choices.build }
@@ -22,11 +22,9 @@ class PoolsController < ApplicationController
   end
 
   def edit
-    @pool = current_user.pools.find(params[:id])
   end
 
   def update
-    @pool = current_user.pools.find(params[:id])
     if @pool.update(pool_params)
       redirect_to @pool
     else
@@ -39,9 +37,16 @@ class PoolsController < ApplicationController
     @membership = current_user.memberships.new(pool_id: @pool.id)
   end
 
-
+  def start
+    @pool.update(started_at: DateTime.now) unless @pool.started_at
+    redirect_to @pool
+  end
 
   private
+
+  def set_pool
+    @pool = current_user.participating_pools.find(params[:id])
+  end
 
   def pool_params
     params.require(:pool).permit(:name, :associated_game, :date, :multiple_entries, :completed, :invite_code)

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -3,7 +3,7 @@ class PoolsController < ApplicationController
 
   def show
     @pool = current_user.participating_pools.find(params[:id])
-    @questions = @pool.questions
+    @questions = @pool.saved_questions
     @question = @pool.questions.new
     2.times { @question.choices.build }
   end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -1,12 +1,16 @@
 class Pool < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :user_id }
-  
+
   belongs_to :user
   has_many :memberships
   has_many :questions
   has_many :entries
 
   after_create_commit :add_invite_code
+
+  def saved_questions
+    questions.where.not(id: nil)
+  end
 
   private
 

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -1,6 +1,6 @@
 <%= @pool.name %>
 
-<%= button_to "Create New Entry!",  pool_entries_path(@pool) %>
+<%= button_to "Create New Entry!",  pool_entries_path(@pool), disabled: @pool.started_at%>
 
 <% if policy(@pool).admin? %>
   <% @pool.memberships.each do |membership| %>
@@ -8,28 +8,33 @@
     <%= button_to "Remove User", membership, method: :delete %>
   <% end %>
 
-  <h2>Create questions</h2>
-  <%= form_for @question do |f| %>
-    <%= f.hidden_field :pool_id, value: @pool.id %>
-    <%= f.label :text, "Question text" %>
-    <%= f.text_field :text %>
-    <%= f.fields_for :choices do |ff| %>
-      <%= ff.label :text, "Choice text" %>
-      <%= ff.text_field :text %>
-    <% end %>
+  <% unless @pool.started_at %>
+    <h2>Create questions</h2>
+    <%= form_for @question do |f| %>
+      <%= f.hidden_field :pool_id, value: @pool.id %>
+      <%= f.label :text, "Question text" %>
+      <%= f.text_field :text %>
+      <%= f.fields_for :choices do |ff| %>
+        <%= ff.label :text, "Choice text" %>
+        <%= ff.text_field :text %>
+      <% end %>
 
-    <%= f.submit "Create Question!" %>
+      <%= f.submit "Create Question!" %>
+    <% end %>
   <% end %>
-  <h3>Existing questions</h3>
-  <% @questions.each do |question| %>
-    <ul>
-      <li><%= question.text %></li>
+
+  <% if @pool.saved_questions.any? %>
+    <h3>Existing questions</h3>
+    <% @questions.each do |question| %>
       <ul>
-        <% question.choices.each do |choice| %>
-          <li><%= choice.text %></li>
-        <% end %>
+        <li><%= question.text %></li>
+        <ul>
+          <% question.choices.each do |choice| %>
+            <li><%= choice.text %></li>
+          <% end %>
+        </ul>
       </ul>
-    </ul>
+    <% end %>
 
   <% end %>
 <% end %>

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -3,6 +3,7 @@
 <%= button_to "Create New Entry!",  pool_entries_path(@pool), disabled: @pool.started_at%>
 
 <% if policy(@pool).admin? %>
+  <%= button_to "Start pool", start_pool_path(@pool), method: :put, disabled: @pool.started_at %>
   <% @pool.memberships.each do |membership| %>
     <%= membership.user.email %>
     <%= button_to "Remove User", membership, method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     resources :entries, only: [:create, :show, :update]
     member do
       get "/membership", to: "pools#membership"
+      put "/start", to: "pools#start"
     end
   end
 

--- a/db/migrate/20210214035733_add_started_at_to_pool.rb
+++ b/db/migrate/20210214035733_add_started_at_to_pool.rb
@@ -1,0 +1,5 @@
+class AddStartedAtToPool < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pools, :started_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_07_024335) do
+ActiveRecord::Schema.define(version: 2021_02_14_035733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2021_02_07_024335) do
     t.string "invite_code"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "started_at"
     t.index ["user_id"], name: "index_pools_on_user_id"
   end
 

--- a/spec/features/pools/admin_can_start_pool_spec.rb
+++ b/spec/features/pools/admin_can_start_pool_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Admin can start a pool", type: :feature do
+  let(:pool) { create(:pool, started_at: nil) }
+  let(:user) { pool.user }
+
+  before { login_as(user, scope: :user) }
+
+  it "redirects back to pool and has started_at time" do
+    visit pool_path(pool)
+
+    click_button("Start pool")
+
+    expect(current_path).to eq(pool_path(pool))
+    expect(page).to have_button("Start pool", disabled: true)
+  end
+end

--- a/spec/features/questions/admin_cannot_add_questions_to_a_pool_that_has_started_spec.rb
+++ b/spec/features/questions/admin_cannot_add_questions_to_a_pool_that_has_started_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "Admin cannot add questions to a pool that has started_spec", type: :feature do
+  let(:pool) { create(:pool, started_at: DateTime.now) }
+  let(:user) { pool.user }
+
+  before { login_as(user, scope: :user) }
+
+  it "does not allow an admin to add questions" do
+    visit pool_path(pool)
+
+    expect(page).to have_content(pool.name)
+    expect(page).not_to have_content("Create questions")
+    expect(page).not_to have_content("Question text")
+  end
+end

--- a/spec/models/pool_spec.rb
+++ b/spec/models/pool_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe Pool, type: :model do
-  describe "validations" do
-    before { create(:pool) }
+  let!(:pool) { create(:pool) }
 
+  describe "validations" do
     it { should validate_presence_of :name }
     it { should validate_uniqueness_of(:name).scoped_to(:user_id) }
   end
@@ -16,6 +16,24 @@ describe Pool, type: :model do
   end
 
   describe "methods" do
+    describe "#saved_questions" do
+      let!(:saved_question) { create(:question, pool: pool) }
+      let!(:unsaved_question) { build(:question, pool: pool) }
+      let!(:unrelated_question) { create(:question) }
+
+      subject(:pool_saved_questions) { pool.saved_questions }
+
+      it "includes saved questions" do
+        expect(pool_saved_questions).to include(saved_question)
+        expect(pool_saved_questions).not_to include(unrelated_question)
+      end
+
+      it "does not include unsaved questions" do
+        expect(pool_saved_questions).not_to include(unsaved_question)
+        expect(pool_saved_questions).not_to include(unrelated_question)
+      end
+    end
+
     describe "callbacks" do
       describe "#create_invite_code" do
         let(:pool) { build(:pool) }

--- a/spec/requests/pools_controller_request_spec.rb
+++ b/spec/requests/pools_controller_request_spec.rb
@@ -95,4 +95,41 @@ describe PoolsController, type: :request do
       end
     end
   end
+
+  describe "GET#membership"
+
+  describe "PUT#start" do
+    let(:pool) { create(:pool) }
+    let(:user) { pool.user }
+
+    before { sign_in(user) }
+
+    subject(:put_start) { put start_pool_path(pool) }
+
+    describe "if the pool has not been started" do
+      it "has 302 status" do
+        put_start
+
+        expect(response).to have_http_status(302)
+      end
+
+      it "should start the pool" do
+        expect { put_start }.to change { pool.reload; pool.started_at }
+      end
+    end
+
+    describe "if the pool has already been started" do
+      before { pool.update(started_at: DateTime.now) }
+
+      it "has 302 status" do
+        put_start
+
+        expect(response).to have_http_status(302)
+      end
+
+      it "does not change the started_at" do
+        expect { put_start }.not_to change { pool.reload; pool.started_at }
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

Closes #29 

# Description

A `pool` needs a designation that it has started. This PR will add a timestamp attribute to the pools table. If this attribute is nil, the `pool` will not be started, if it has a timestamp, it will be considered started.

This `started_at` attribute will be used to allow an admin to add more questions or choices to a pool and also to determine if a user can be allowed to submit or change an entry to a pool.